### PR TITLE
update types to reflect real data

### DIFF
--- a/lib/api/models/Product.d.ts
+++ b/lib/api/models/Product.d.ts
@@ -764,10 +764,11 @@ export type CsvType = {
     isWithShipping: boolean;
     isExtraData: boolean;
 };
+export type CsvTypeKeys = 'AMAZON' | 'NEW' | 'USED' | 'SALES' | 'LISTPRICE' | 'COLLECTIBLE' | 'REFURBISHED' | 'NEW_FBM_SHIPPING' | 'LIGHTNING_DEAL' | 'WAREHOUSE' | 'NEW_FBA' | 'RATING' | 'COUNT_REVIEWS' | 'BUY_BOX_SHIPPING' | 'BUY_BOX_USED_SHIPPING' | 'PRIME_EXCL';
 /**
  * Enum representing CSV types for various price histories and product attributes.
  */
-export declare const CsvTypes: Record<string, CsvType>;
+export declare const CsvTypes: Record<CsvTypeKeys, CsvType>;
 /**
  * Returns the corresponding CsvType by index.
  * @param index - The index value to match.

--- a/lib/api/models/Product.d.ts
+++ b/lib/api/models/Product.d.ts
@@ -454,7 +454,7 @@ export type Product = {
     /**
      * Contains subcategory rank histories. Each key represents the categoryId of the rank with the history in the corresponding value.
      */
-    salesRanks?: Map<number, number[]>;
+    salesRanks?: Map<string, number[]>;
     /**
      * The category node id of the main sales rank. -1 if not available.
      */
@@ -630,7 +630,7 @@ export type Product = {
      * price: 4900 => $ 49.00 (if domainId is 5, Japan, then price: 4900 => ¥ 4900)<br>
      * A price of '-1' means that there was no offer at the given timestamp (e.g. out of stock).
      */
-    csv?: number[][];
+    csv?: (number[] | null)[];
 };
 /**
  * Represents a video associated with a product.
@@ -700,10 +700,11 @@ export type UnitCountObject = {
  * Contains detailed FBA fees. If the total fee is 0 the product does not have (valid) dimensions and thus the fee can not be calculated.
  */
 export type FBAFeesObject = {
-    storageFee: number;
-    storageFeeTax: number;
-    pickAndPackFee: number;
-    pickAndPackFeeTax: number;
+    lastUpdate: number;
+    storageFee?: number;
+    storageFeeTax?: number;
+    pickAndPackFee?: number;
+    pickAndPackFeeTax?: number;
 };
 /**
  * Represents hazardous material information.

--- a/src/api/models/Product.ts
+++ b/src/api/models/Product.ts
@@ -904,10 +904,28 @@ export type CsvType = {
   isExtraData: boolean;
 };
 
+export type CsvTypeKeys =
+  | 'AMAZON'
+  | 'NEW'
+  | 'USED'
+  | 'SALES'
+  | 'LISTPRICE'
+  | 'COLLECTIBLE'
+  | 'REFURBISHED'
+  | 'NEW_FBM_SHIPPING'
+  | 'LIGHTNING_DEAL'
+  | 'WAREHOUSE'
+  | 'NEW_FBA'
+  | 'RATING'
+  | 'COUNT_REVIEWS'
+  | 'BUY_BOX_SHIPPING'
+  | 'BUY_BOX_USED_SHIPPING'
+  | 'PRIME_EXCL';
+
 /**
  * Enum representing CSV types for various price histories and product attributes.
  */
-export const CsvTypes: Record<string, CsvType> = {
+export const CsvTypes: Record<CsvTypeKeys, CsvType> = {
   /**
    * Amazon price history
    */

--- a/src/api/models/Product.ts
+++ b/src/api/models/Product.ts
@@ -541,7 +541,7 @@ export type Product = {
   /**
    * Contains subcategory rank histories. Each key represents the categoryId of the rank with the history in the corresponding value.
    */
-  salesRanks?: Map<number, number[]>;
+  salesRanks?: Map<string, number[]>;
 
   /**
    * The category node id of the main sales rank. -1 if not available.
@@ -751,7 +751,7 @@ export type Product = {
    * price: 4900 => $ 49.00 (if domainId is 5, Japan, then price: 4900 => ¥ 4900)<br>
    * A price of '-1' means that there was no offer at the given timestamp (e.g. out of stock).
    */
-  csv?: number[][];
+  csv?: (number[] | null)[];
 };
 
 /**
@@ -830,10 +830,11 @@ export type UnitCountObject = {
  * Contains detailed FBA fees. If the total fee is 0 the product does not have (valid) dimensions and thus the fee can not be calculated.
  */
 export type FBAFeesObject = {
-  storageFee: number;
-  storageFeeTax: number;
-  pickAndPackFee: number;
-  pickAndPackFeeTax: number;
+  lastUpdate: number;
+  storageFee?: number;
+  storageFeeTax?: number;
+  pickAndPackFee?: number;
+  pickAndPackFeeTax?: number;
 };
 
 /**


### PR DESCRIPTION
This pull request includes several changes to the `Product` model in `src/api/models/Product.ts` to improve type definitions and add new types. The most important changes include modifying the `salesRanks` and `csv` properties, updating the `FBAFeesObject` type, and introducing a new type for `CsvTypeKeys`.

Improvements to type definitions:

* Changed the type of the `salesRanks` property from `Map<number, number[]>` to `Map<string, number[]>` to better reflect the category IDs as strings.
* Updated the `csv` property type to `(number[] | null)[]` to account for possible null values in the array.

Enhancements to `FBAFeesObject`:

* Added an optional `lastUpdate` property and made existing fee properties optional to handle cases where fees may not be available.

Introduction of new types:

* Added a new type `CsvTypeKeys` to enumerate the possible keys for `CsvTypes`, ensuring type safety and better code readability.

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
